### PR TITLE
adapt template to existing latex and word templates

### DIFF
--- a/abstract.typ
+++ b/abstract.typ
@@ -3,7 +3,18 @@
 #let abstract = (
   de: [
     // De
-    #lorem(100)
+    Der Abstract einer Abschlussarbeit sollte eine kurze Zusammenfassung 
+    enthalten, damit der Leser nach einigen Sätzen einen Eindruck davon 
+    bekommt, welches Thema bearbeitet wurde. Ein Abstract ist dabei kein 
+    „Teaser“ sondern eher eine „Executive Summary“. #linebreak()
+    Dieses Dokument dient als Vorlage und gleichzeitig als kleine Anleitung, 
+    um eine Abschlussarbeit mit Typst zu erstellen. Um das Template für die 
+    eigene Abschlussarbeit zu verwenden, kann einfach der vorhandene Text 
+    gelöscht und eigener Text hinzugefügt werden. Das Dokument enthält keine 
+    ausführliche Erklärung für das Arbeiten mit Typst, da es hierzu eine 
+    ausführliche Anleitung der Entwickler:innen gibt. Stattdessen enthält es 
+    einige Tipps und eine Dokumentation mit der es einfach sein sollte das 
+    Template zu nutzen und zu modifizieren. 
   ],
   eng: [
     // Eng

--- a/addendum/addendum.typ
+++ b/addendum/addendum.typ
@@ -4,7 +4,12 @@
 
 == Anhang X <anhang-x>
 
-#lorem(200)
+Der Anhang kann Teile der Arbeit enthalten, die im Hauptteil zu weit führen würden,
+aber trotzdem für manche Leser interessant sein könnten. Das können z. B. die
+Ergebnisse weiterer Messungen sein, die im Hauptteil nicht betrachtet werden aber
+trotzdem durchgeführt wurden. Es ist ebenfalls möglich längere Codeabschnitte
+anzuhängen. Jedoch sollte der Anhang kein Ersatz für ein Repository sein und nicht
+einfach den gesamten Code enthalten.
 
 #pagebreak(weak: true)
 

--- a/chapter/conclusion.typ
+++ b/chapter/conclusion.typ
@@ -1,0 +1,6 @@
+= Zusammenfassung und Ausblick
+
+Im letzten Kapitel sollte die Arbeit zusammengefasst und ein Fazit gezogen werden.
+Außerdem sollte beschrieben werden, wie es mit dem Projekt weitergehen kann
+und welche Punkte vielleicht interessant wären aber im Rahmen der Arbeit nicht
+bearbeitet werden konnten.

--- a/chapter/furtherchapters.typ
+++ b/chapter/furtherchapters.typ
@@ -1,0 +1,11 @@
+= Weitere Kapitel
+
+Natürlich enthält die Arbeit noch weitere Kapitel. Welche genau für Deine Ar-
+beit wichtig sind, hängt von der Art der Arbeit ab und sollte mit der Betreuer:in
+besprochen werden.
+
+== Unterkapitel
+
+=== Unterunterkapitel
+
+==== Unterunterunterkapitel

--- a/chapter/introduction.typ
+++ b/chapter/introduction.typ
@@ -1,139 +1,15 @@
-#import "/template/utils.typ": *
+= Einleitung
 
-= Das Template
-
-== Struktur
-
-_/acronym.typ_ Akronyme festgelegt.
-#ac("VR")
-
-_/abstract.typ_ DE und ENG Variante vom abstract
-
-_/foreword.typ_ Vorbemerkungen falls benötigt
-
-_/glossar.typ_ glossar einträge definieren @thumbstick:pl
-
-_/literature.bib_ Literatur im BibLatex Format (Zotero + Better Bibtex Plugin mit Auto Export wird sehr empfohlen)
-
-_/software.typ_ Für die Arbeit verwendete Software (nicht immer notwendig)
+Die Einleitung erklärt den Kontext der eigenen Arbeit und führt zur Fragestellung
+hin, die bearbeitet wurde. Es sollte klar werden, in welchem Bereich die Arbeit
+verfasst wurde und warum sie relevant ist. Im Gegensatz zum Abstract wird die
+Arbeit hier nicht zusammengefasst. Am Ende der Einleitung kann der Aufbau der
+restlichen Arbeit erläutert werden.
 
 
-== Referenzieren <chap::intro:ref>
+== Struktur der Arbeit
 
-Abschnitte referenzieren @chap::intro:ref
-
-```typ
-@chap::intro:ref
-```
-#line(length: 100%)
-
-Abbildung referenzieren @fig:figure-a
-
-```typ
-@fig:figure-a
-```
-
-#figure(
-  image("../template/imis-logo.png", width: 80%),
-  caption: [
-    A step in the molecular testing
-    pipeline of our lab.
-  ],
-) <figure-a>
-#line(length: 100%)
-Anhang referenzieren
-
-```typ
-@anhang-x
-```
-
-@anhang-x
-
-== utils
-
-Die Utils sind eine Ansammlung an nützlichen funktionen. Diese müssen in jedem File in dem sie verwendet werde importiert werden (siehe Zeile 1 in _/chapter/introduction.typ_)
-
-```typ
-#import "/template/utils.typ": *
-```
-
-=== Abk.
-Verschiedene Funktionen des acrotastic packages werden in kruzform über die Utils bereitgestellt.
-
-```typ
-#acf("VR")
-```
-#acf("VR")
-
-=== Glossar
-Verschiedene Funktionen des glossarium packages werden in kruzform über die Utils bereitgestellt.
-
-```typ
-@thumbstick:long:pl
-```
-@thumbstick:long:pl
-
-=== Zitation
-Zitationen (prose)
-
-```typ
-#tc(<abeele2021>)
-```
-#tc(<abeele2021>)
-
-=== Text notes
-
-Inline Needs Citation label
-
-```typ
-#needs-citation
-```
-#needs-citation
-
-#line(length: 100%)
-
-```typ
-#todo[]
-```
-
-#todo[]
-
-#line(length: 100%)
-
-```typ
-#todo-b[#lorem(20)]
-```
-#todo-b[#lorem(20)]
-
-#line(length: 100%)
-
-```typ
-#wip[]
-#wip-b[#lorem(20)]
-```
-
-#wip[]
-#wip-b[#lorem(20)]
-
-#line(length: 100%)
-
-```typ
-#question[#lorem(20)]
-#question[#lorem(20)
-  #answer[42]
-]
-```
-
-#question[#lorem(20)]
-#question[#lorem(20)
-  #answer[42]
-]
-
-#line(length: 100%)
-
-```typ
-#done[]
-```
-
-#done[]
+Es gibt unterschiedliche Strukturen, wie eine Qualifizierungsarbeit aufgebaut sein
+kann. Es ist daher sinnvoll, die Struktur der eigenen Arbeit mit der Betreuer:in zu
+besprechen.
 

--- a/chapter/relatedwork.typ
+++ b/chapter/relatedwork.typ
@@ -1,0 +1,7 @@
+= Verwandte Arbeiten oder Stand der Forschung
+
+Der Stand der Forschung oder das Kapitel „Verwandte Arbeiten“ dient dazu, die
+Forschungsfrage/Hypothesen herzuleiten und den Gegenstand der eigenen Arbeit in
+ein größeres Forschungsfeld einzubetten. Dabei sollten fremde Arbeiten nicht einfach
+„aufgelistet“ werden sondern sollten inhaltlich diskutiert (und ggfs. kritisiert) werden.
+Kann ggfs. auch als Unterkapitel des ersten Kapitels eingegliedert werden.

--- a/chapter/tutorial.typ
+++ b/chapter/tutorial.typ
@@ -1,0 +1,139 @@
+#import "/template/utils.typ": *
+
+= Tutorial zu diesem Typst Template
+
+== Struktur
+
+_/acronym.typ_ Akronyme festgelegt.
+#ac("VR")
+
+_/abstract.typ_ DE und ENG Variante vom abstract
+
+_/foreword.typ_ Vorbemerkungen falls benötigt
+
+_/glossar.typ_ glossar einträge definieren @thumbstick:pl
+
+_/literature.bib_ Literatur im BibLatex Format (Zotero + Better Bibtex Plugin mit Auto Export wird sehr empfohlen)
+
+_/software.typ_ Für die Arbeit verwendete Software (nicht immer notwendig)
+
+
+== Referenzieren <chap::intro:ref>
+
+Abschnitte referenzieren @chap::intro:ref
+
+```typ
+@chap::intro:ref
+```
+#line(length: 100%)
+
+Abbildung referenzieren @fig:figure-a
+
+```typ
+@fig:figure-a
+```
+
+#figure(
+  image("../template/imis-logo.png", width: 80%),
+  caption: [
+    A step in the molecular testing
+    pipeline of our lab.
+  ],
+) <figure-a>
+#line(length: 100%)
+Anhang referenzieren
+
+```typ
+@anhang-x
+```
+
+@anhang-x
+
+== utils
+
+Die Utils sind eine Ansammlung an nützlichen funktionen. Diese müssen in jedem File in dem sie verwendet werde importiert werden (siehe Zeile 1 in _/chapter/introduction.typ_)
+
+```typ
+#import "/template/utils.typ": *
+```
+
+=== Abk.
+Verschiedene Funktionen des acrotastic packages werden in kruzform über die Utils bereitgestellt.
+
+```typ
+#acf("VR")
+```
+#acf("VR")
+
+=== Glossar
+Verschiedene Funktionen des glossarium packages werden in kruzform über die Utils bereitgestellt.
+
+```typ
+@thumbstick:long:pl
+```
+@thumbstick:long:pl
+
+=== Zitation
+Zitationen (prose)
+
+```typ
+#tc(<abeele2021>)
+```
+#tc(<abeele2021>)
+
+=== Text notes
+
+Inline Needs Citation label
+
+```typ
+#needs-citation
+```
+#needs-citation
+
+#line(length: 100%)
+
+```typ
+#todo[]
+```
+
+#todo[]
+
+#line(length: 100%)
+
+```typ
+#todo-b[#lorem(20)]
+```
+#todo-b[#lorem(20)]
+
+#line(length: 100%)
+
+```typ
+#wip[]
+#wip-b[#lorem(20)]
+```
+
+#wip[]
+#wip-b[#lorem(20)]
+
+#line(length: 100%)
+
+```typ
+#question[#lorem(20)]
+#question[#lorem(20)
+  #answer[42]
+]
+```
+
+#question[#lorem(20)]
+#question[#lorem(20)
+  #answer[42]
+]
+
+#line(length: 100%)
+
+```typ
+#done[]
+```
+
+#done[]
+

--- a/main.typ
+++ b/main.typ
@@ -2,15 +2,20 @@
 #import "abstract.typ": *
 
 #let title = (
-  de: "Titel einer Qualifikationsarbeit am IMIS der Universität zu Lübeck",
-  eng: "Title of a thesis at the IMIS of the University of Lübeck",
+  de: "Titel der Arbeit",
+  eng: "Titel der Arbeit in Englisch",
 )
 
 #show: thesis.with(
   title: title,
-  author: "Author B.Sc.",
-  prof: "Univ.-Prof. Maxim Mustermensch",
-  support: "Bente Betreuer:in",
+  thesis-type: "Bachelorarbeit/Masterarbeit",
+  author: "Vorname Nachname",
+  prof: "Titel Name Erstgutachter:in",
+  support: "Titel Name Betreuer:in",
+  company: (
+    show-company: true,
+    name: "Firma Muster GmbH"
+  ),
   print: true,
   one-sided: false,
   abstract: (abstract),
@@ -21,3 +26,7 @@
 )
 
 #include "chapter/introduction.typ"
+#include "chapter/relatedwork.typ"
+#include "chapter/furtherchapters.typ"
+#include "chapter/conclusion.typ"
+#include "chapter/tutorial.typ"

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -34,9 +34,11 @@
 /// - keywords (de: str, eng: str): keywords belonging to this thesis
 #let thesis(
   title: (de: "", eng: ""),
+  thesis-type: "",
   author: "",
   prof: "",
   support: "",
+  company: (show-company: true, name: ""),
   date: datetime.today(),
   abstract: (de: "", eng: ""),
   keywords: (de: "", eng: ""),
@@ -123,15 +125,23 @@
   //show heading: set text(font: "Atkinson Hyperlegible")
 
   // -- Content --
+  
+  // define if company text is shown
+  let company-text(company-name) = if company.show-company {
+    text(
+      "Die Arbeit ist im Rahmen einer Tätigkeit bei der Firma " + 
+      company-name + 
+      " entstanden."
+    ) 
+  }
 
   // --- Title Page ---
   align(center)[
     #set par(leading: 0.65em, spacing: 0.85em) // Line Height
 
     #image("imis-logo.png")
-    #text(fill: color.hsl(0deg, 0%, 50%))[
-      Direktor: Univ.-Prof. Dr.-Ing. Nicole Jochems Dipl.-Inform.
-    ] #v(3em, weak: true)
+
+    #v(3em, weak: true)
 
     #par(
       text(
@@ -150,7 +160,7 @@
       ),
     ) #v(3.5em, weak: true)
 
-    *Masterarbeit* #v(1.5em, weak: true)
+    *#thesis-type* #v(1.5em, weak: true)
 
     im Rahmen des Studiengangs \ *Medieninformatik* \ der Universität zu Lübeck
 
@@ -172,7 +182,12 @@
 
     *#support*
 
+    #v(2em, weak: true)
+
+    #company-text(company.name)
+
     #v(3em, weak: true)
+    
 
     Lübeck, #date.display("[day padding:none]. [month repr:long] [year]")
   ]
@@ -286,42 +301,6 @@
     outline(depth: 3)
   }
 
-
-  // Glossar and acronyms
-  [
-    // Change heading style only for this block
-    #set page(numbering: "i", footer: none)
-    #set heading(numbering: none, outlined: true)
-    #show heading.where(level: 1): it => [
-      #if one-sided {
-        pagebreak()
-      } else {
-        pagebreak(to: "odd")
-      }
-      #v(1.5em)
-      #it
-      #v(1.5em)
-    ]
-    #show heading.where(level: 2): it => [
-      #v(1.5em)
-      #it
-      #v(0.75em)
-    ]
-
-    // --- Table of Acronyms ---
-    #if (acronyms.len() > 0) {
-      acrostiche.print-index(
-        title: [Abkürzungen],
-        delimiter: "",
-        outlined: true,
-        sorted: "up",
-        row-gutter: 1em,
-      )
-    }
-
-    // --- Glossar ---
-    #glossy.glossary(title: "Glossar", sort: true)
-  ]
 
   // Reset page counter for main part
   counter(page).update(0)
@@ -509,6 +488,39 @@
 
   include "/software.typ"
 
+  // Glossar and acronyms
+  [
+    // Change heading style only for this block
+    #show heading.where(level: 1): it => [
+      #if one-sided {
+        pagebreak()
+      } else {
+        pagebreak(to: "odd")
+      }
+      #v(1.5em)
+      #it
+      #v(1.5em)
+    ]
+    #show heading.where(level: 2): it => [
+      #v(1.5em)
+      #it
+      #v(0.75em)
+    ]
+
+    // --- Table of Acronyms ---
+    #if (acronyms.len() > 0) {
+      acrostiche.print-index(
+        title: [Abkürzungen],
+        delimiter: "",
+        outlined: true,
+        sorted: "up",
+        row-gutter: 1em,
+      )
+    }
+
+    // --- Glossar ---
+    #glossy.glossary(title: "Glossar", sort: true)
+  ]
 
   // -- Addendum --
   show figure: it => i-figured.show-figure(it, numbering: "A.1")


### PR DESCRIPTION
Hey there,
since the current template version is not quite the same as the the existing word and latex templates
I've changed the structure to match the existing templates. In addition to that I added the chapter descriptions from the 
original templates with some minor adaptions (change latex to typst and so on).
Furthermore I made some changes to the titel page such as changing the placeholders and adding the company thingy which can be toggled via the template.

See the following change log for a detailed overview:

rework title page
- change placeholder text fields
- add company field:
  - company name can be set as template attribute
  - if company field will be shown, can be set as template attribute

change struktur to match the official latex and word templates
- move Abkürzungen and Glossar to the end
- move template chapter from introduction to own file
- rename template chapter to "Tutorial zu diesem Typst Template"
- add example chapters:
  - "Einleitung"
  - "Verwandte Arbeiten oder Stand der Forschung"
  - "Weitere Kapitel"
  - "Zusammenfassung und Ausblick"
- add adapted template text using the latex and word template